### PR TITLE
feat(samba): support service.loadBalancerIP

### DIFF
--- a/charts/samba/Chart.yaml
+++ b/charts/samba/Chart.yaml
@@ -3,5 +3,5 @@ name: samba
 description: A Helm chart for Samba Time Machine on Kubernetes
 icon: https://www.samba.org/samba/img/samba-logo.png
 type: application
-version: 3.1.2
+version: 3.1.3
 appVersion: "smbd-only-latest"

--- a/charts/samba/README.md
+++ b/charts/samba/README.md
@@ -1,6 +1,6 @@
 # samba
 
-![Version: 3.1.2](https://img.shields.io/badge/Version-3.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: smbd-only-latest](https://img.shields.io/badge/AppVersion-smbd-only-latest-informational?style=flat-square)
+![Version: 3.1.3](https://img.shields.io/badge/Version-3.1.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: smbd-only-latest](https://img.shields.io/badge/AppVersion-smbd-only-latest-informational?style=flat-square)
 
 A Helm chart for Samba Time Machine on Kubernetes
 
@@ -94,6 +94,7 @@ helm uninstall samba -n samba
 | securityContext | object | `{}` | Security context for the container (applies to the main container) |
 | service | object | See `values.yaml` | Service configuration |
 | service.externalTrafficPolicy | string | empty | External traffic policy (Local, Cluster) - Only valid for LoadBalancer and NodePort services Preserves source IP address when set to Local. Requires health checks on all nodes. |
+| service.loadBalancerIP | string | empty | Requested LoadBalancer IP (MetalLB / cloud LB); only used when type is LoadBalancer |
 | service.ports | object | See `values.yaml` | Service ports configuration |
 | service.ports.tcp139 | int | `139` | NetBIOS Name Service port (TCP) - Used for NetBIOS name resolution |
 | service.ports.tcp445 | int | `445` | SMB/CIFS port (TCP) - Main file sharing port for SMB protocol |

--- a/charts/samba/templates/service.yaml
+++ b/charts/samba/templates/service.yaml
@@ -7,6 +7,9 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
 spec:
   type: {{ .Values.service.type }}
+  {{- if .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
   {{- if .Values.service.externalTrafficPolicy }}
   externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
   {{- end }}

--- a/charts/samba/values.yaml
+++ b/charts/samba/values.yaml
@@ -73,6 +73,9 @@ terminationGracePeriodSeconds: ""
 service:
   # -- Kubernetes service type (ClusterIP, NodePort, LoadBalancer)
   type: ClusterIP
+  # -- Requested LoadBalancer IP (MetalLB / cloud LB); only used when type is LoadBalancer
+  # @default -- empty
+  loadBalancerIP: ""
   # -- External traffic policy (Local, Cluster) - Only valid for LoadBalancer and NodePort services
   # Preserves source IP address when set to Local. Requires health checks on all nodes.
   # @default -- empty


### PR DESCRIPTION
## Summary
- Add optional `service.loadBalancerIP` to the Samba chart Service template
- Document the value and bump chart version to **3.1.3**
- Regenerated helm-docs README

This lets MetalLB (and similar) pin a stable VIP, matching how other home services are configured.

## Test plan
- [ ] `helm template` with `service.type=LoadBalancer` and `service.loadBalancerIP=192.168.40.38` renders `spec.loadBalancerIP`
- [ ] Omitting `loadBalancerIP` leaves the field unset
- [ ] Chart release publishes `samba-3.1.3`
- [ ] Consume from k8s-apps timemachine app after release


Made with [Cursor](https://cursor.com)